### PR TITLE
RPMsg-Lite: Cache was mistakenly disabled for SC598 bare-metal exampl…

### DIFF
--- a/rpmsg-lite-examples/adsp-sc598-som-ezkit/sc598-ezkit-arm-bm-led-toggle/sc598-ezkit-arm-bm-led-toggle_Core1/src/sc598-ezkit-arm-bm-led-toggle_Core1.c
+++ b/rpmsg-lite-examples/adsp-sc598-som-ezkit/sc598-ezkit-arm-bm-led-toggle/sc598-ezkit-arm-bm-led-toggle_Core1/src/sc598-ezkit-arm-bm-led-toggle_Core1.c
@@ -269,9 +269,6 @@ int rpmsg_init_channel_to_ARM(void){
 	return 0;
 }
 
-/* Disable prefetch buffers for SC598 as it causes issues with triggering other SHARC */
-const uint32_t __prefetch_ctrl = 0;
-
 int main(int argc, char *argv[])
 {
 	int32_t Result=0, loop=1;

--- a/rpmsg-lite-examples/adsp-sc598-som-ezkit/sc598-ezkit-arm-bm-led-toggle/sc598-ezkit-arm-bm-led-toggle_Core2/src/sc598-ezkit-arm-bm-led-toggle_Core2.c
+++ b/rpmsg-lite-examples/adsp-sc598-som-ezkit/sc598-ezkit-arm-bm-led-toggle/sc598-ezkit-arm-bm-led-toggle_Core2/src/sc598-ezkit-arm-bm-led-toggle_Core2.c
@@ -152,9 +152,6 @@ int rpmsg_init_channel_to_SHARC(void) {
 	return 0;
 }
 
-/* Disable prefetch buffers for SC598 as it causes issues with triggering other SHARC */
-const uint32_t __prefetch_ctrl = 0;
-
 int main(int argc, char *argv[]) {
 
 	int32_t Result=0, loop=1;

--- a/rpmsg-lite-examples/adsp-sc598-som-ezkit/sc598-ezkit-bm-led-toggle/sc598-ezkit-bm-led-toggle_Core1/system.svc
+++ b/rpmsg-lite-examples/adsp-sc598-som-ezkit/sc598-ezkit-bm-led-toggle/sc598-ezkit-bm-led-toggle_Core1/system.svc
@@ -24,7 +24,7 @@ It provides information needed to link your code. It can be used to configure me
 					</propertygroup>
 					<propertygroup name="template_schemas" value="true">
 						<property name="ldf_schema" value="211.03"/>
-						<property name="startup_code_schema" value="211.03"/>
+						<property name="startup_code_schema" value="212.01"/>
 					</propertygroup>
 					<crt>
 						<propertygroup name="cplb_init" value="true">
@@ -87,19 +87,19 @@ It provides information needed to link your code. It can be used to configure me
 					</ldf>
 				</crt_and_ldf>
 				<sharc_caches>
-					<propertygroup name="icache" value="false">
-						<property name="disabled" value="true"/>
+					<propertygroup name="icache" value="true">
+						<property name="disabled" value="false"/>
 						<property name="size_in_KB" value="16"/>
 					</propertygroup>
-					<propertygroup name="pmcache" value="false">
-						<property name="disabled" value="true"/>
+					<propertygroup name="pmcache" value="true">
+						<property name="disabled" value="false"/>
 						<property name="size_in_KB" value="16"/>
 					</propertygroup>
-					<propertygroup name="dmcache" value="false">
-						<property name="disabled" value="true"/>
+					<propertygroup name="dmcache" value="true">
+						<property name="disabled" value="false"/>
 						<property name="size_in_KB" value="16"/>
 					</propertygroup>
-					<propertygroup name="cache_ranges" value="false">
+					<propertygroup name="cache_ranges" value="true">
 						<property name="noncacheable_arm_sdram" value="true"/>
 					</propertygroup>
 				</sharc_caches>

--- a/rpmsg-lite-examples/adsp-sc598-som-ezkit/sc598-ezkit-bm-led-toggle/sc598-ezkit-bm-led-toggle_Core2/system.svc
+++ b/rpmsg-lite-examples/adsp-sc598-som-ezkit/sc598-ezkit-bm-led-toggle/sc598-ezkit-bm-led-toggle_Core2/system.svc
@@ -24,7 +24,7 @@ It provides information needed to link your code. It can be used to configure me
 					</propertygroup>
 					<propertygroup name="template_schemas" value="true">
 						<property name="ldf_schema" value="211.03"/>
-						<property name="startup_code_schema" value="211.03"/>
+						<property name="startup_code_schema" value="212.01"/>
 					</propertygroup>
 					<crt>
 						<propertygroup name="cplb_init" value="true">
@@ -87,19 +87,19 @@ It provides information needed to link your code. It can be used to configure me
 					</ldf>
 				</crt_and_ldf>
 				<sharc_caches>
-					<propertygroup name="icache" value="false">
-						<property name="disabled" value="true"/>
+					<propertygroup name="icache" value="true">
+						<property name="disabled" value="false"/>
 						<property name="size_in_KB" value="16"/>
 					</propertygroup>
-					<propertygroup name="pmcache" value="false">
-						<property name="disabled" value="true"/>
+					<propertygroup name="pmcache" value="true">
+						<property name="disabled" value="false"/>
 						<property name="size_in_KB" value="16"/>
 					</propertygroup>
-					<propertygroup name="dmcache" value="false">
-						<property name="disabled" value="true"/>
+					<propertygroup name="dmcache" value="true">
+						<property name="disabled" value="false"/>
 						<property name="size_in_KB" value="16"/>
 					</propertygroup>
-					<propertygroup name="cache_ranges" value="false">
+					<propertygroup name="cache_ranges" value="true">
 						<property name="noncacheable_arm_sdram" value="true"/>
 					</propertygroup>
 				</sharc_caches>

--- a/rpmsg-lite-examples/adsp-sc598-som-ezkit/sc598-freertos-led-toggle/sc598-freertos-led-toggle_Core1/src/sc598-freertos-led-toggle_Core1.c
+++ b/rpmsg-lite-examples/adsp-sc598-som-ezkit/sc598-freertos-led-toggle/sc598-freertos-led-toggle_Core1/src/sc598-freertos-led-toggle_Core1.c
@@ -21,9 +21,6 @@
  */
 char __argv_string[] = "";
 
-/* Disable prefetch buffers for SC598 as it causes issues with triggering other SHARC */
-const uint32_t __prefetch_ctrl = 0;
-
 int main(int argc, char *argv[])
 {
 	/**

--- a/rpmsg-lite-examples/adsp-sc598-som-ezkit/sc598-freertos-led-toggle/sc598-freertos-led-toggle_Core2/src/sc598-freertos-led-toggle_Core2.c
+++ b/rpmsg-lite-examples/adsp-sc598-som-ezkit/sc598-freertos-led-toggle/sc598-freertos-led-toggle_Core2/src/sc598-freertos-led-toggle_Core2.c
@@ -21,9 +21,6 @@
  */
 char __argv_string[] = "";
 
-/* Disable prefetch buffers for SC598 as it causes issues with triggering other SHARC */
-const uint32_t __prefetch_ctrl = 0;
-
 int main(int argc, char *argv[])
 {
 	/**


### PR DESCRIPTION
…e which caused prefetch to behave as a mini cache. This then had to be disabled to establish communication between SHARC cores. Re-enabled the cache and removed the prefetch disable as that is no longer required

Compiled with latest CCES studio. 